### PR TITLE
Fix close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/recws-org/recws
+module github.com/p4u/recws
 
 go 1.13
 

--- a/recws.go
+++ b/recws.go
@@ -54,7 +54,7 @@ type RecConn struct {
 	httpResp    *http.Response
 	dialErr     error
 	dialer      *websocket.Dialer
-
+	close       chan (bool)
 	*websocket.Conn
 }
 
@@ -87,7 +87,7 @@ func (rc *RecConn) Close() {
 		rc.Conn.Close()
 		rc.mu.Unlock()
 	}
-
+	rc.close <- true
 	rc.setIsConnected(false)
 }
 
@@ -290,6 +290,7 @@ func (rc *RecConn) Dial(urlStr string, reqHeader http.Header) {
 		log.Fatalf("Dial: %v", err)
 	}
 
+	rc.close = make(chan bool, 1)
 	// Config
 	rc.setURL(urlStr)
 	rc.setReqHeader(reqHeader)
@@ -394,43 +395,48 @@ func (rc *RecConn) connect() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	for {
-		nextItvl := b.Duration()
-		wsConn, httpResp, err := rc.dialer.Dial(rc.url, rc.reqHeader)
-
-		rc.mu.Lock()
-		rc.Conn = wsConn
-		rc.dialErr = err
-		rc.isConnected = err == nil
-		rc.httpResp = httpResp
-		rc.mu.Unlock()
-
-		if err == nil {
-			if !rc.getNonVerbose() {
-				log.Printf("Dial: connection was successfully established with %s\n", rc.url)
-			}
-
-			if rc.hasSubscribeHandler() {
-				if err := rc.SubscribeHandler(); err != nil {
-					log.Fatalf("Dial: connect handler failed with %s", err.Error())
-				}
-				if !rc.getNonVerbose() {
-					log.Printf("Dial: connect handler was successfully established with %s\n", rc.url)
-				}
-			}
-
-			if rc.getKeepAliveTimeout() != 0 {
-				rc.keepAlive()
-			}
-		
+		select {
+		case <-rc.close:
 			return
-		}
+		default:
+			nextItvl := b.Duration()
+			wsConn, httpResp, err := rc.dialer.Dial(rc.url, rc.reqHeader)
 
-		if !rc.getNonVerbose() {
-			log.Println(err)
-			log.Println("Dial: will try again in", nextItvl, "seconds.")
-		}
+			rc.mu.Lock()
+			rc.Conn = wsConn
+			rc.dialErr = err
+			rc.isConnected = err == nil
+			rc.httpResp = httpResp
+			rc.mu.Unlock()
 
-		time.Sleep(nextItvl)
+			if err == nil {
+				if !rc.getNonVerbose() {
+					log.Printf("Dial: connection was successfully established with %s\n", rc.url)
+				}
+
+				if rc.hasSubscribeHandler() {
+					if err := rc.SubscribeHandler(); err != nil {
+						log.Fatalf("Dial: connect handler failed with %s", err.Error())
+					}
+					if !rc.getNonVerbose() {
+						log.Printf("Dial: connect handler was successfully established with %s\n", rc.url)
+					}
+				}
+
+				if rc.getKeepAliveTimeout() != 0 {
+					rc.keepAlive()
+				}
+
+				return
+			}
+
+			if !rc.getNonVerbose() {
+				log.Println(err)
+				log.Println("Dial: will try again in", nextItvl, "seconds.")
+			}
+
+			time.Sleep(nextItvl)
+		}
 	}
 }
 


### PR DESCRIPTION
This is required in order to terminate the connect() lopp.

If this is not applied, after calling Close() the connect goroutine would keep iterating and trying to reconnect