### PR TITLE
Fix reconnect logic

### DIFF
--- a/recws.go
+++ b/recws.go
@@ -54,7 +54,8 @@ type RecConn struct {
 	httpResp    *http.Response
 	dialErr     error
 	dialer      *websocket.Dialer
-	close       chan (bool)
+	// if set to true, close stops dial reconnection
+	close chan (bool)
 
 	*websocket.Conn
 }
@@ -291,9 +292,7 @@ func (rc *RecConn) Dial(urlStr string, reqHeader http.Header) {
 		log.Fatalf("Dial: %v", err)
 	}
 
-	// Close channel
 	rc.close = make(chan bool, 1)
-	
 	// Config
 	rc.setURL(urlStr)
 	rc.setReqHeader(reqHeader)


### PR DESCRIPTION
Reverted the commit recws-org/recws@1726c45 as it has broken the reconnect logic in case of error.
Forbidden to create a new connect() goroutine in case there is already one running (fixed the issue recws-org#20).