### PR TITLE
Fix reconnection logic, removed unused method

### DIFF
--- a/recws.go
+++ b/recws.go
@@ -54,7 +54,8 @@ type RecConn struct {
 	httpResp    *http.Response
 	dialErr     error
 	dialer      *websocket.Dialer
-	close       chan (bool)
+	// if set to true, close stops dial reconnection
+	close chan (bool)
 
 	*websocket.Conn
 }
@@ -291,9 +292,7 @@ func (rc *RecConn) Dial(urlStr string, reqHeader http.Header) {
 		log.Fatalf("Dial: %v", err)
 	}
 
-	// Close channel
 	rc.close = make(chan bool, 1)
-	
 	// Config
 	rc.setURL(urlStr)
 	rc.setReqHeader(reqHeader)

--- a/recws.go
+++ b/recws.go
@@ -81,13 +81,6 @@ func (rc *RecConn) setIsConnecting(state bool) {
 	rc.isConnecting = state
 }
 
-func (rc *RecConn) getConn() *websocket.Conn {
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
-
-	return rc.Conn
-}
-
 // Close closes the underlying network connection without
 // sending or waiting for a close frame.
 func (rc *RecConn) Close() {


### PR DESCRIPTION
Reverted the commit 1726c45 as it has broken the reconnect logic in case of error.
Forbidden to create a new connect() goroutine in case there is already one running (fixed the issue #20).