### PR TITLE
Add Shutdown method to gracefully close websocket

### DIFF
--- a/recws.go
+++ b/recws.go
@@ -116,7 +116,7 @@ func (rc *RecConn) ReadMessage() (messageType int, message []byte, err error) {
 			rc.Close()
 			return messageType, message, nil
 		}
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+		if err != nil {
 			rc.CloseAndReconnect()
 		}
 	}
@@ -138,7 +138,7 @@ func (rc *RecConn) WriteMessage(messageType int, data []byte) error {
 			rc.Close()
 			return nil
 		}
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+		if err != nil {
 			rc.CloseAndReconnect()
 		}
 	}
@@ -162,7 +162,7 @@ func (rc *RecConn) WriteJSON(v interface{}) error {
 			rc.Close()
 			return nil
 		}
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+		if err != nil {
 			rc.CloseAndReconnect()
 		}
 	}
@@ -185,7 +185,7 @@ func (rc *RecConn) ReadJSON(v interface{}) error {
 			rc.Close()
 			return nil
 		}
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+		if err != nil {
 			rc.CloseAndReconnect()
 		}
 	}

--- a/recws.go
+++ b/recws.go
@@ -16,8 +16,6 @@ import (
 	"github.com/jpillora/backoff"
 )
 
-const writeWait = time.Second
-
 // ErrNotConnected is returned when the application read/writes
 // a message and the connection is closed
 var ErrNotConnected = errors.New("websocket: not connected")
@@ -94,7 +92,8 @@ func (rc *RecConn) Close() {
 }
 
 // Shutdown gracefully closes the connection by sending the websocket.CloseMessage.
-func (rc *RecConn) Shutdown() {
+// The writeWait param defines the duration before the deadline of the write operation is hit.
+func (rc *RecConn) Shutdown(writeWait time.Duration) {
 	msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
 	err := rc.WriteControl(websocket.CloseMessage, msg, time.Now().Add(writeWait))
 	if err != nil && err != websocket.ErrCloseSent {


### PR DESCRIPTION
- Add Shutdown() method
- Adjust error handling on read and write method to allow for graceful shutdown